### PR TITLE
AppUser Serializers (/users app)

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -10,7 +10,7 @@ class UserSerializer(serializers.ModelSerializer):
     password = serializers.CharField(required=True)
     first_name = serializers.CharField(required=True)
     last_name = serializers.CharField(required=True)
-    email = serializers.CharField()
+    email = serializers.EmailField()
     is_superuser = serializers.BooleanField(default=False)
     class Meta:
         model = User
@@ -25,6 +25,7 @@ class AppUserSerializer(serializers.ModelSerializer):
         model = AppUser 
         fields = ('user', 'prof_type')
 
+    #overrides default create
     def create(self, validated_data):
         """
         Create and return a new AppUser instance, given the validated data.
@@ -36,6 +37,7 @@ class AppUserSerializer(serializers.ModelSerializer):
         email = validated_data.pop('email')
         is_superuser = validated_data.pop('is_superuser')
 
+        #.create_user automatically hashes the password field
         user = User.objects.create_user(
             username=username,
             password=password,
@@ -47,6 +49,7 @@ class AppUserSerializer(serializers.ModelSerializer):
         appUser = AppUser.objects.create(user=user, **validated_data)
         return appUser
 
+    #overrides default update
     def update(self, instance, validated_data):
         """
         Update and return an existing AppUser instance, given the validated data.

--- a/users/tests.py
+++ b/users/tests.py
@@ -36,6 +36,7 @@ class AppUserSerializerTest(TestCase):
             'prof_type': 'TP'
         }
 
+        #serialize into an AppUser object
         self.app_user = AppUser.objects.create(**self.app_user_attributes)
         self.serializer = AppUserSerializer(instance=self.app_user)
 
@@ -82,4 +83,65 @@ class AppUserSerializerTest(TestCase):
         }
         serializer = AppUserSerializer(data=serialized_data)
         self.assertTrue(serializer.is_valid())
+
+    
+    def test_create_appuser_obj(self):
+        serialized_data = {
+            'user':{
+                'username': 'abcdef',
+                'password': '123',
+                'first_name': 'Abc',
+                'last_name': 'Def',
+                'email': 'abc@uvic.ca',
+                'is_superuser': False
+            },
+            'prof_type': 'TP'
+        }
+        serializer = AppUserSerializer(data=serialized_data)
+        self.assertTrue(serializer.is_valid())
+
+        #use the serializer to create an AppUser record, then assert it has been committed to DB
+        app_user_obj = serializer.save()
+        self.assertIsNotNone(app_user_obj.pk)
+
+    
+    def test_update_appuser_obj(self):
+        serialized_data = {
+            'user':{
+                'username': 'abcdef',
+                'password': '123',
+                'first_name': 'Abc',
+                'last_name': 'Def',
+                'email': 'abc@uvic.ca',
+                'is_superuser': False
+            },
+            'prof_type': 'TP'
+        }
+        serializer = AppUserSerializer(data=serialized_data)
+        self.assertTrue(serializer.is_valid())
+
+        #use the serializer to create an AppUser record
+        app_user_obj = serializer.save()
+        obj_key = app_user_obj.pk
         
+        #now, update the AppUser record order by referencing an existing instance
+        updated_serialized_data = {
+            'user':{
+                'username': 'ghijkl',   #updated field
+                'password': '123',
+                'first_name': 'Abc',
+                'last_name': 'Def',
+                'email': 'abc@uvic.ca',
+                'is_superuser': False
+            },
+            'prof_type': 'RP'   #updated field
+        }
+        serializer = AppUserSerializer(instance=app_user_obj, data=updated_serialized_data)
+        self.assertTrue(serializer.is_valid())
+        updated_app_user = serializer.save()
+        updated_obj_key = updated_app_user.pk
+
+        #assert that the same instance was updated, and updated as expected
+        self.assertEquals(updated_obj_key, obj_key)
+        self.assertEquals(AppUser.objects.get(pk=obj_key).user.username, updated_serialized_data['user']['username'])
+        self.assertEquals(AppUser.objects.get(pk=obj_key).prof_type, updated_serialized_data['prof_type'])

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,4 +1,4 @@
-from django.test import TestCase    #**tests that interact with database require subclassing of this class**
+from django.test import TestCase    #**tests that interact with a database require subclassing of this class**
 
 from django.contrib.auth.models import User
 from .models import AppUser
@@ -21,7 +21,7 @@ class AppUserSerializerTest(TestCase):
 
         self.app_user_attributes = {
             'user': self.user,
-            'prof_type': AppUser.TeachingType.TEACHING_PROF
+            'prof_type': 'RP'
         }
         #default data for the serializer, if needed
         self.default_serializer_data = {
@@ -33,7 +33,7 @@ class AppUserSerializerTest(TestCase):
                 'email': 'abc@uvic.ca',
                 'is_superuser': False
             },
-            'prof_type': AppUser.TeachingType.TEACHING_PROF
+            'prof_type': 'TP'
         }
 
         self.app_user = AppUser.objects.create(**self.app_user_attributes)
@@ -46,7 +46,7 @@ class AppUserSerializerTest(TestCase):
             'user',
             'prof_type']))
 
-    #FIX
+
     def test_user_contains_expected_fields(self):
         data = self.serializer.data
         self.assertEqual(set(data['user'].keys()), set([
@@ -66,3 +66,5 @@ class AppUserSerializerTest(TestCase):
     def test_prof_type_field_content(self):
         data = self.serializer.data
         self.assertEqual(data['prof_type'], self.app_user_attributes['prof_type'])
+
+        

--- a/users/tests.py
+++ b/users/tests.py
@@ -49,7 +49,7 @@ class AppUserSerializerTest(TestCase):
     #FIX
     def test_user_contains_expected_fields(self):
         data = self.serializer.data
-        self.assertEqual(set(data.user.keys()), set([
+        self.assertEqual(set(data['user'].keys()), set([
             'username',
             'password',
             'first_name',

--- a/users/tests.py
+++ b/users/tests.py
@@ -67,4 +67,19 @@ class AppUserSerializerTest(TestCase):
         data = self.serializer.data
         self.assertEqual(data['prof_type'], self.app_user_attributes['prof_type'])
 
+    
+    def test_valid_deserialization(self):
+        serialized_data = {
+            'user':{
+                'username': 'abcdef',
+                'password': '123',
+                'first_name': 'Abc',
+                'last_name': 'Def',
+                'email': 'abc@uvic.ca',
+                'is_superuser': False
+            },
+            'prof_type': 'TP'
+        }
+        serializer = AppUserSerializer(data=serialized_data)
+        self.assertTrue(serializer.is_valid())
         


### PR DESCRIPTION
Serializers for the AppUser model required to complete ticket #18 .

Create() and update() method were overridden to handle the extended Django auth.User model. Unit tests include basic sanity checks for accessing serialized/deserialized fields, and AppUser instance creation & AppUser instance updating, which trigger database commits. Tests can be ran using the basic Django test command while selecting the `users` app test suite: `... manage.py test users`

Once this gets merged into the original feature branch, I can rebase the feature branch onto main's recently updated HEAD.