### PR TITLE
Remove password field requirement for /users/{id} endpoints

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -15,7 +15,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('username', 'password', 'first_name', 'last_name', 'email', 'is_superuser')
-        extra_kwargs = {'password': {'write_only': True}}
+        extra_kwargs = {'password': {'write_only': True, 'required': False}}
 
     #overrides default update
     def update(self, instance, validated_data):

--- a/users/test_views.py
+++ b/users/test_views.py
@@ -46,6 +46,20 @@ class TestProfessorsList(TestCase):
             'is_form_submitted': False,
         }
 
+        #default data containing no password field for the serializer
+        self.no_password_serializer_data = {
+            'user': {
+                'username': 'abcdef',
+                'first_name': 'Abc',
+                'last_name': 'Def',
+                'email': 'abc@uvic.ca',
+                'is_superuser': False
+            },
+            'prof_type': AppUser.TeachingType.TEACHING_PROF,
+            'is_peng': False,
+            'is_form_submitted': False,
+        }
+
         self.app_user = AppUser.objects.create(**self.app_user_attributes)
         self.serializer = AppUserSerializer(instance=self.app_user)
 
@@ -64,8 +78,16 @@ class TestProfessorsList(TestCase):
         if serializer.is_valid():
             serializer.save()
 
+    @classmethod
+    #save an AppUser instance using data that does not contain a password
+    def save_default_user_no_password(self):
+        serializer = AppUserSerializer(data=self.no_password_serializer_data)
+        if serializer.is_valid():
+            serializer.save()
+
     def test_prof_update_POST(self):
-        self.save_default_user()
+        #assures that the serializer does not need a password field during .update()
+        self.save_default_user_no_password()
         response = self.get_APIClient().post('/api/users/abcdef/', data=self.default_serializer_data, format='json')
         self.assertIsNotNone(response)
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/users/views.py
+++ b/users/views.py
@@ -35,8 +35,12 @@ class ProfessorsList(APIView):
     def post(self, request: HttpRequest, format=None) -> HttpResponse:
         if request.method != "POST":
             return HttpResponse(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
         request_data = JSONParser().parse(request)
+
+        #upon Prof creation, manually assert that a password was provided in the request body
+        if 'password' not in request_data['user']:
+            return HttpResponse("No password was provided for the new Professor account!", status=status.HTTP_400_BAD_REQUEST)
+
         serializer = AppUserSerializer(data=request_data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
- serializer is updated to accept AppUser data with both a password and a lack of a password
- views logic updated for `CREATE /users` to assert that a password field does exist (required to create a Prof account)
- update the UPDATE /users/{id} test to send password-less data