### PR TITLE
Fixed bug with integrating with algorithms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,8 @@ RUN pip install --upgrade pip
 COPY ./requirements.txt .
 RUN pip install -r requirements.txt
 
-# IDK why but that's needed.
-# You have no idea how desperate I was to try that
-RUN pip uninstall -y coursescheduler
-RUN pip install coursescheduler
+COPY ./requirements-testpypi.txt .
+RUN pip install -r requirements-testpypi.txt
 
 # Copy entrypoint.sh
 COPY ./entrypoint.sh /scheduler_service/entrypoint.sh

--- a/requirements-testpypi.txt
+++ b/requirements-testpypi.txt
@@ -1,0 +1,9 @@
+# Requirements to be installed from test.pypi go in this file
+# so that there is no index confusion for pip
+# Requirements from pypi should be in requirements.txt
+
+--extra-index-url https://test.pypi.org/simple/
+capacityforecaster==0.2.6 #Company 2 alg 2 (from pypi.org/simple/ index)
+
+--extra-index-url https://test.pypi.org/simple/
+c1algo2==0.0.7 #Company 1 alg 2 (from pypi.org/simple/ index)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,17 @@
+# Requirements to be installed from pypi go in this file
+# so that there is no index confusion for pip
+# Requirements from test.pypi should be in requirements-testpypi.txt
+
 Django==4.0.1
 djangorestframework==3.13.1
-psycopg2==2.9.3
+psycopg2-binary==2.9.3
 djangorestframework-simplejwt==5.2.0
 django-cors-headers==3.13.0
 pyjwt==2.4.0
 
-
 # algorithms
 coursescheduler==0.0.6 #Company 2 alg 1
 c1algo1==2.0.3 # Company 1 alg 1
-
---extra-index-url https://test.pypi.org/simple/
-capacityforecaster==0.2.6 #Company 2 alg 2 (from pypi.org/simple/ index)
-
---extra-index-url https://test.pypi.org/simple/
-c1algo2==0.0.7 #Company 1 alg 2 (from pypi.org/simple/ index)
-
 
 # dependencies from c1algo2
 numpy


### PR DESCRIPTION
It was revealed to me in a dream that pip might be getting version 0.0.6 of coursescheduler from test.pypi instead of pypi. 
The version on test.pypi is super outdated and doesn't work. This would explain the flaky behaviour we were experiencing. 

This indeed seems to have been the case, as I can remove the line uninstalling it and reinstalling it without error. 

Not too sure how to verify this was the problem, but we can always revert back to the uninstall and reinstall in the Dockerfile if this isn't a permanent fix. 