### PR TITLE
Fix is_form_submitted flag bug

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -34,7 +34,7 @@ class AppUserSerializer(serializers.ModelSerializer):
     user = UserSerializer()
     prof_type = serializers.ChoiceField(choices=AppUser.TeachingType, default=AppUser.TeachingType.TEACHING_PROF)
     is_peng = serializers.BooleanField(default=False)
-    is_form_submitted = serializers.BooleanField(default=False)
+    is_form_submitted = serializers.BooleanField()
 
     class Meta: 
         model = AppUser 

--- a/users/test_views.py
+++ b/users/test_views.py
@@ -45,6 +45,20 @@ class TestProfessorsList(TestCase):
             'is_peng': False,
             'is_form_submitted': False,
         }
+        
+        # Update default data for the serializer, if needed
+        self.update_default_serializer_data = {
+            'user': {
+                'username': 'abcdef',
+                'first_name': 'Abc',
+                'last_name': 'Def',
+                'email': 'abc@uvic.ca',
+                'is_superuser': False
+            },
+            'prof_type': AppUser.TeachingType.TEACHING_PROF,
+            'is_peng': False,
+            'is_form_submitted': True, # Updated
+        }
 
         #default data containing no password field for the serializer
         self.no_password_serializer_data = {
@@ -91,6 +105,13 @@ class TestProfessorsList(TestCase):
         response = self.get_APIClient().post('/api/users/abcdef/', data=self.default_serializer_data, format='json')
         self.assertIsNotNone(response)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
+    
+    def test_prof_update_POST__is_submitted_flag_set(self):
+        self.save_default_user()
+        response = self.get_APIClient().post('/api/users/abcdef/', data=self.update_default_serializer_data, format='json')
+        self.assertIsNotNone(response)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertContains(response, "\"is_form_submitted\": true")
 
     def test_prof_creation_POST(self):
         response = self.get_APIClient().post('/api/users/', data=self.default_serializer_data, format='json')


### PR DESCRIPTION
Update AppUser serializers to no longer set is_form_submitted flag to a default value. Instead it will stay whatever is passed into the serializer. Added a test cause to make sure the update keeps it as is.

I think the bug was that if a request was made without the is_form_submitted set, it would automatically set it to false. Now the field is required and if nothing is provided, will cause a 400 error and return is_form_submitted in the body. 

Closes https://github.com/seng499-company2/back-end/issues/95