### PR TITLE
Implement second Schedule serializer for Company1

### DIFF
--- a/schedule/Schedule_serializers.py
+++ b/schedule/Schedule_serializers.py
@@ -44,3 +44,32 @@ class A_ScheduleSerializer(serializers.ModelSerializer):
         fields = ['fall', 'spring', 'summer']
 
 
+#---Company1 Schedule-related serializers: removes A_CourseSection.maxCapacity fields---
+class A_Company1CourseSectionSerializer(serializers.ModelSerializer):
+    professor = serializers.JSONField(allow_null=True)                      #Ex: #{"id": <int>, "name": Mike Zastre}
+    capacity = serializers.IntegerField(max_value=None, min_value=0)
+    timeSlots = A_TimeSlotSerializer(many=True, read_only=True)             #nested & many-to-many
+    class Meta:
+        model = A_CourseSection
+        fields = ['professor', 'capacity', 'timeSlots']
+
+
+class A_Company1CourseOfferingSerializer(serializers.ModelSerializer):
+    course = A_CourseSerializer(read_only=True)                             #nested & many-to-one
+    sections = A_Company1CourseSectionSerializer(many=True, read_only=True) #nested & many-to-many
+    class Meta:
+        model = A_CourseOffering
+        fields = ['course', 'sections']
+
+
+class A_Company1ScheduleSerializer(serializers.ModelSerializer):
+    fall = A_Company1CourseOfferingSerializer(many=True, read_only = True)
+    spring = A_Company1CourseOfferingSerializer(many=True, read_only = True)
+    summer = A_Company1CourseOfferingSerializer(many=True, read_only = True)
+    class Meta:
+        model = A_Schedule
+        fields = ['fall', 'spring', 'summer']
+
+
+
+


### PR DESCRIPTION
Completes ticket #119 .

Adds a new serializer for Company1 that is simply an old copy of the Schedule serializer we used to have. Serialization removes all instances of `maxCapacity` fields for a CourseSection object, without touching the DB models - therefore we can easily build both types of Schedule objects from the same DB data, by using either serializer when needed.

This work will help the ongoing refactoring of Course & Schedule related views.

Sample JSON Schedule object differences:
![image](https://user-images.githubusercontent.com/59449281/180620302-ff167993-d38f-428c-8b9d-5bdfacd50b39.png)
