### PR TITLE
Fix Time Merging edge case where a preferredTimes semester key is null

### DIFF
--- a/schedule/alg_data_generator.py
+++ b/schedule/alg_data_generator.py
@@ -88,7 +88,7 @@ def merge_preferred_times(unmerged_preferred_times):
 
     for semester in unmerged_preferred_times:
         #handle edge case where some semester may not have any preferredTimes - must set to None
-        if unmerged_preferred_times[semester] == 'null':
+        if not unmerged_preferred_times[semester]:
             merged_times[semester] = None
             continue
 

--- a/schedule/alg_data_generator.py
+++ b/schedule/alg_data_generator.py
@@ -85,7 +85,13 @@ def merge_preferred_times(unmerged_preferred_times):
         "spring": {},
         "summer": {}
     }
+
     for semester in unmerged_preferred_times:
+        #handle edge case where some semester may not have any preferredTimes - must set to None
+        if unmerged_preferred_times[semester] == 'null':
+            merged_times[semester] = None
+            continue
+
         for key in unmerged_preferred_times[semester]:
             unmerged_list = unmerged_preferred_times[semester][key]
 

--- a/schedule/tests.py
+++ b/schedule/tests.py
@@ -363,7 +363,7 @@ class ViewTest(TestCase):
                         [["10:00", "16:00"]],
                     "wednesday":
                         [["10:00", "19:00"]]},
-                "summer": {}
+                "summer": None
             },
             "preferredCoursesPerSemester": {
                   "fall": 2,


### PR DESCRIPTION
Edge case should now be handled in the `alg_data_generator`. We check for `"null"` specifically because this is a JSONField in our model.